### PR TITLE
Исправить обработку аргументов

### DIFF
--- a/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
+++ b/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
@@ -194,9 +194,10 @@ public class JPackageMojo extends AbstractMojo {
             addParameter(parameters, "--java-options", options);
         }
 
-        if (arguments != null && arguments.length > 0) {
-            String appArgs = String.join(" ", arguments);
-            addParameter(parameters, "--arguments", appArgs);
+        if (arguments != null) {
+            for (String argument : arguments) {
+                addParameter(parameters, "--arguments", argument);
+            }
         }
 
         if (isMac()) {

--- a/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
+++ b/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
@@ -231,7 +231,7 @@ public class JPackageMojo extends AbstractMojo {
         if (value == null || value.isEmpty()) {
             return;
         }
-        value = value.contains(" ") ? "\"" + value + "\"" : value;
+        value = "\"" + value.replace("\"", "\\\"") + "\"";
 
         getLog().info(name + " " + value);
         params.add(name);

--- a/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
+++ b/src/main/java/org/panteleyev/jpackage/JPackageMojo.java
@@ -117,8 +117,15 @@ public class JPackageMojo extends AbstractMojo {
     private boolean linuxShortcut;
 
     public void execute() throws MojoExecutionException {
-        String jpackage = getJPackageExecutable();
-        getLog().info("Using: " + jpackage);
+        String jpackage;
+        try {
+            jpackage = getJPackageExecutable();
+            getLog().info("Using: " + jpackage);
+        } catch (Exception e) {
+            getLog().warn("Can't get jpackage location by toolchaing, trying with 'jpackage': " +
+                    e.getMessage());
+            jpackage = "jpackage";
+        }
 
         validateParameters();
 


### PR DESCRIPTION
PR создан для отражения изменений относительно версии 0.3.3 в основном репозитории https://github.com/petr-panteleyev/jpackage-maven-plugin
1. `--arguments` может использоваться многократно (https://openjdk.org/jeps/343)
2. Экранирование кавычек в аргументах 
3. Fallback: искать утилиту `jpackage` в PATH

На текущей момент основной репозиторий содержит все изменения в версии 1.6.6 (в виде отрефакторенного кода). Заявка может быть закрыта.

Duplicates https://github.com/petr-panteleyev/jpackage-maven-plugin/pull/2